### PR TITLE
Enforce lower-case keys for headers

### DIFF
--- a/lib/revision_plate/app.rb
+++ b/lib/revision_plate/app.rb
@@ -28,7 +28,7 @@ module RevisionPlate
 
     def call(env)
       unless ACCEPT_METHODS.include?(env['REQUEST_METHOD']) && (@path ? env['PATH_INFO'] == @path : true)
-        return [404, {'Content-Type' => 'text/plain'}, []]
+        return [404, {'content-type' => 'text/plain'}, []]
       end
 
       if @revision
@@ -44,7 +44,7 @@ module RevisionPlate
         body = ["REVISION_FILE_NOT_FOUND\n"]
       end
 
-      headers = {'Content-Type' => 'text/plain'}
+      headers = {'content-type' => 'text/plain'}
       if env['REQUEST_METHOD'] == 'HEAD'
         [status, headers, []]
       else

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -14,7 +14,7 @@ class AppTest < Minitest::Spec
   describe 'middleware' do
     let(:tempfile) { Tempfile.new('revision_plate-middielware-test') }
 
-    let(:nextapp) { -> (env) { [200, {'Content-Type' => 'text/plain'}, ['hi']] } }
+    let(:nextapp) { -> (env) { [200, {'content-type' => 'text/plain'}, ['hi']] } }
     let(:mockapp) do
       Class.new do
         def self.instances
@@ -30,7 +30,7 @@ class AppTest < Minitest::Spec
         attr_reader :file, :options
 
         def call(env)
-          [200, {'Content-Type' => 'text/plain'}, "deadbeef"]
+          [200, {'content-type' => 'text/plain'}, "deadbeef"]
         end
 
         const_set(:ACCEPT_METHODS, %w[GET HEAD].freeze)


### PR DESCRIPTION
Rack v3 disallows upper-case characters in header keys. https://github.com/rack/rack/commit/472e12f5b6505cc2fdd3b5e529b616b3a2d5fbf8
These keys are also prohibited by Rack::Lint::LintError. https://github.com/rack/rack/blob/3.0.0/lib/rack/lint.rb#L653